### PR TITLE
(bugfix) fix numdiff build on OSX

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -124,10 +124,10 @@ test -f "$LSSTSW/lsst_build/.deployed" || ( # Clone lsst_build
 test -f "${LSSTSW}/lfs/bin/numdiff" || (
     echo "::: Deploying numdiff"
     cd ${LSSTSW}/sources
-    wget http://download-mirror.savannah.gnu.org/releases//numdiff/numdiff-5.6.1.tar.gz
-    tar -xvf numdiff-5.6.1.tar.gz
-    cd numdiff-5.6.1
-    ./configure --prefix=${LSSTSW}/lfs
+    curl -# -L -O http://download-mirror.savannah.gnu.org/releases//numdiff/numdiff-5.8.1.tar.gz
+    tar -xzf numdiff-5.8.1.tar.gz
+    cd numdiff-5.8.1
+    ./configure --prefix=${LSSTSW}/lfs --disable-nls
     make -j4
     make install
 )


### PR DESCRIPTION
- per @mjuric the `--disable-nls` flag is needed on OSX 10.10 as gettext may not be present
- use `curl` instead of `wget`
- untar without `-v` to reduce scroll shock