### PR TITLE
drop git + anaconda from PRODUCTS

### DIFF
--- a/etc/settings.cfg.sh
+++ b/etc/settings.cfg.sh
@@ -3,7 +3,7 @@
 #
 
 # top-level products
-PRODUCTS='lsst_sims lsst_distrib qserv_distrib git anaconda webserv'
+PRODUCTS='lsst_sims lsst_distrib qserv_distrib webserv'
 
 # set it to nonempty to prevent versiondb from being pushed upstream
 # unless you're the automated LSST software account


### PR DESCRIPTION
Neither of these packages are top level products.  There are presently no deps
on git and only one on anaconda.