### PR TITLE
feature/SIM-1209/splitOffGalSim

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -75,6 +75,7 @@ activemqcpp: https://github.com/lsst/activemqcpp.git
 pex_harness: https://github.com/lsst-dm/legacy-pex_harness.git
 git: https://github.com/lsst/git.git
 sims_catUtils: https://github.com/lsst/sims_catUtils.git
+sims_GalSimInterface: https://github.com/lsst/sims_GalSimInterface.git
 qserv_testdata: https://github.com/lsst/qserv_testdata
 eigen: https://github.com/lsst/eigen.git
 healpy: https://github.com/lsst/healpy.git


### PR DESCRIPTION
this pull request adds the sims_GalSimInterface to the repos.yaml file in lsstsw so that lsstsw knows where to clone sims_GalSimInterface