### PR TITLE
New LSST repos added

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -127,3 +127,5 @@ tmv: https://github.com/lsst/tmv.git
 sncosmo: https://github.com/lsst/sncosmo.git
 sims_operations: https://github.com/lsst/sims_operations.git
 display_ds9: https://github.com/lsst/display_ds9
+meas_extensions_psfex: https://github.com/lsst/meas_extensions_psfex.git
+psfex: https://github.com/lsst/psfex.git


### PR DESCRIPTION
Repositories were added for meas_extensions_psfex, and psfex. This was part
of a merge from the HSC code base