### PR TITLE
(DM-4113) add an optional `lfs` key to repos.yaml hash format

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -9,6 +9,7 @@ source ${SCRIPT_DIR}/../etc/settings.cfg.sh
 EUPS_VERSION=${EUPS_VERSION:-1.5.9}         # Version of EUPS to install
 MINICONDA_VERSION=${MINICONDA_VERSION:-latest} # Version of Miniconda to install
 GIT_VERSION=${GIT_VERSION:-2.2.2}           # Version of git to install
+LFS_VERSION=${LFS_VERSION:-1.0.2}           # Version of git-lfs to install
 
 set -e
 
@@ -72,6 +73,28 @@ test -f "$LSSTSW/lfs/.git.deployed" || ( # git
     tar xzf "$LSSTSW/sources/git-manpages-${GIT_VERSION}.tar.gz"
     (cd "$LSSTSW" && git config push.default current)
     touch "$LSSTSW/lfs/.git.deployed"
+)
+
+test -f "${LSSTSW}/lfs/.git-lfs.deployed" || (
+    echo "::: Deploying git-lfs"
+
+    case $(uname -s) in
+        Linux*)  lfs_platform="linux-amd64" ;;
+        Darwin*) lfs_platform="darwin-amd64" ;;
+        *)
+            echo "Cannot install git-lfs: unsupported platform $(uname -s)"
+            exit 1
+            ;;
+    esac
+
+    cd sources
+    LFS_BASE_URL="https://github.com/github/git-lfs/releases/download"
+    LFS_ARCHIVE="git-lfs-${lfs_platform}-${LFS_VERSION}.tar.gz"
+    curl -# -L -O "${LFS_BASE_URL}/v${LFS_VERSION}/${LFS_ARCHIVE}"
+    tar xzf $LFS_ARCHIVE
+    cp git-lfs-${LFS_VERSION}/git-lfs ${LSSTSW}/lfs/bin/
+    cd $LSSTSW
+    touch "${LSSTSW}/lfs/.git-lfs.deployed"
 )
 
 # backwards compatibility if EUPS wasn't installed to a versioned directory

--- a/bin/repos-lint
+++ b/bin/repos-lint
@@ -7,6 +7,7 @@ import socket
 from urllib.parse import urlparse
 from urllib.request import urlopen
 import argparse
+from colors import red, green, yellow, blue, faint, bold
 
 parser = argparse.ArgumentParser()
 parser.add_argument("filename")
@@ -14,20 +15,28 @@ args = parser.parse_args()
 
 product_pattern = re.compile('^[A-z_0-9]+$')
 
+def print_good(s, *args):
+    # ansicolor assumes the first argument is a string
+    print(green(str(s), *args))
+
+def print_bad(s, *args):
+    # ansicolor assumes the first argument is a string
+    print(red(str(s), *args))
+
 def check_product(pkg):
-    print('%16s: ' % 'product name', end='')
+    print(faint(('%16s: ' % 'product name')), end='')
     try:
         validate_string(pkg)
         validate_product_name(pkg)
     except ValueError as e:
-        print(e)
+        print_bad(e)
         return False
 
-    print('OK')
+    print_good('OK')
     return True
 
 def check_repo_spec(spec):
-    print('%16s: ' % 'repo spec', end='')
+    print(faint(('%16s: ' % 'repo spec')), end='')
 
     try:
         if type(spec) is str:
@@ -37,10 +46,10 @@ def check_repo_spec(spec):
         else:
             raise ValueError('unsupported repo spec type: %s' % type(spec))
     except Exception as e:
-        print(e)
+        print_bad(e)
         return False
 
-    print('OK')
+    print_good('OK')
     return True
 
 def validate_string(s):
@@ -120,12 +129,12 @@ with open(args.filename, 'r') as f:
     # intentionally disallowing subclasses of dict since serialized objects
     # should not be in our configuration file.
     if not type(data) is dict:
-        print('YAML file has an invalid format: must be a Mapping')
+        print_bad('YAML file has an invalid format: must be a Mapping')
         sys.exit(1)
     for k,v in data.items():
         repos += 1
 
-        print('%s: %s' % (k, v))
+        print('%s: %s' % (bold(k), blue(str(v), style='bold')))
         if not check_product(k):
             problemos += 1
         if not check_repo_spec(v):
@@ -134,8 +143,8 @@ with open(args.filename, 'r') as f:
 print()
 print('summary')
 print('===')
-print('%16s: %d' % ('total repos', repos))
-print('%16s: %d' % ('errors', problemos))
+print(yellow('%16s: %d' % ('total repos', repos)))
+print(yellow('%16s: %d' % ('errors', problemos)))
 
 if problemos > 0:
     sys.exit(1)

--- a/bin/repos-lint
+++ b/bin/repos-lint
@@ -27,7 +27,7 @@ def check_product(pkg):
     return True
 
 def check_repo_spec(spec):
-    print('%16s: ' % 'repo url', end='')
+    print('%16s: ' % 'repo spec', end='')
 
     try:
         if type(spec) is str:
@@ -47,32 +47,50 @@ def validate_string(s):
     # intentionally disallowing subclasses of str since serialized objects
     # should not be in our configuration file.
     if not type(s) is str:
-        raise ValueError('is not a string')
+        raise ValueError('is not a str')
+
+def validate_bool(b):
+    # intentionally disallowing subclasses of bool since serialized objects
+    # should not be in our configuration file.
+    if not type(b) is bool:
+        raise ValueError('is not a bool')
 
 def validate_product_name(pkg):
     if not product_pattern.match(pkg):
         raise ValueError('invalid EUPS product name')
 
 def validate_repo_dict(spec):
-    supported_keys = ['url', 'ref']
+    mandatory_keys = ['url']
+    optional_keys = ['ref', 'lfs']
 
-    # currently we only support the url and ref keys
-    if all(key in spec for key in supported_keys):
+    if 'url' in spec:
         validate_repo_url(spec['url'])
+    if 'ref' in spec:
         validate_string(spec['ref'])
+    if 'lfs' in spec:
+        validate_bool(spec['lfs'])
+        if spec['lfs'] != True:
+            raise ValueError('the only supported value for lfs is true')
 
     # missing mandatory keys
-    missing_keys = [ key for key in supported_keys if key not in spec ]
+    missing_keys = [ key for key in mandatory_keys if key not in spec ]
 
     # extra keys
-    unknown_keys = [ key for key in spec if key not in supported_keys ]
+    unknown_keys = [ key for key in spec if key not in (mandatory_keys + optional_keys)]
 
-    if missing_keys or unknown_keys:
+    # at least one optional key is required; this is to prevent url only hashes
+    # which could be simplified
+    no_options = not any(key for key in optional_keys if key in spec)
+
+    if no_options or missing_keys or unknown_keys:
         message = ""
         for k in missing_keys:
             message += "missing mandatory key: %s\n" % k
         for k in unknown_keys:
             message += "unknown key: %s\n" % k
+        if no_options:
+            message += "at least one of these keys is required: %s\n" \
+                    % optional_keys
 
         raise ValueError(message)
 

--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -12,11 +12,13 @@
 # dict/hash/map.  Each keypair specifies a source repo and a specification of
 # how it may be cloned.  Key names must conform to the EUPS product name of the
 # source package.  Values may be either a URL (string) or a dict/hash/map with
-# *exactly* two keys: `url` and `ref`.  The second form generally should be
-# used only if a ref /other than/ `master` should be the default checkout.
+# a `url` key and *at least* one `ref` or `lfs`.  The `ref` key generally
+# should be used only if a ref /other than/ `master` is desired.  The `lfs`
+# key is used to identicate that the repo is using git-lfs.
 #
 # * `url`: string - URL of git repo
 # * `ref`: string - ref (branch | tag) to use by default
+# * `lfs`: boolean - `true` (all lowercase) is the only supported value
 #
 # examples
 # ---
@@ -37,6 +39,10 @@
 #   ^
 #   |
 #   +--  2 space indent declaring a nested dict/hash/map
+#
+#   afwdata:
+#     url: https://github.com/lsst/afwdata.git
+#     lfs: true
 #
 ---
 lsst_thirdparty: https://github.com/lsst/lsst_thirdparty.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+ansicolors==1.0.2
 PyYAML==3.11
 wheel==0.24.0

--- a/tests/repos.yaml.bad
+++ b/tests/repos.yaml.bad
@@ -1,0 +1,28 @@
+---
+#
+# all repo specs in this file should fail
+#
+# check_product
+## name does not conform to eups expectations
+funky-name: https://github.com/lsst/lsstsw.git
+# check_repo_spec
+## url scheme is not native git or https
+invalid_scheme: git@github.com:lsst/lsstsw.git
+## https url is invalid
+invalid_https_url: https://example.dne
+## not in simpliest form; no 'option' keys
+no_option_keys:
+  url: https://github.com/lsst/lsstsw.git
+## missing mandtory 'url' key
+missing_url_key:
+  - thing1
+## extra/undefined keys
+extra_keys:
+  url: https://github.com/lsst/xrootd.git
+  ref: tickets/DM-1662
+  extra: key
+  extra2: key
+## lfs key is not true
+lfs_not_true:
+  url: https://github.com/lsst/lsstsw.git
+  lfs: false

--- a/tests/repos.yaml.good
+++ b/tests/repos.yaml.good
@@ -1,7 +1,10 @@
 ---
+#
+# all repo specs in this file should pass
+#
 https_url: https://github.com/lsst/lsstsw.git
 git_rul: git://git.lsstcorp.org/LSST/DMS/testdata/afwdata.git
-redefined_ref:
+default_ref:
   url: https://github.com/lsst/lsstsw.git
   ref: next
 lfs_enabled:

--- a/tests/repos.yaml.good
+++ b/tests/repos.yaml.good
@@ -1,0 +1,13 @@
+---
+https_url: https://github.com/lsst/lsstsw.git
+git_rul: git://git.lsstcorp.org/LSST/DMS/testdata/afwdata.git
+redefined_ref:
+  url: https://github.com/lsst/lsstsw.git
+  ref: next
+lfs_enabled:
+  url: https://github.com/lsst/lsstsw.git
+  lfs: true
+all_keys:
+  url: https://github.com/lsst/lsstsw.git
+  ref: next
+  lfs: true


### PR DESCRIPTION
The only allowed value is `true` to indicate the repo is using git-lfs.
