### PR TITLE
Remove obs_cfht from repos.yaml

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -66,7 +66,6 @@ xrootd:
 apr_util: https://github.com/lsst/apr_util.git
 daf_persistence: https://github.com/lsst/daf_persistence.git
 obs_lsstSim: https://github.com/lsst/obs_lsstSim.git
-obs_cfht: https://github.com/lsst/obs_cfht.git
 obs_decam: https://github.com/lsst/obs_decam.git
 log: https://github.com/lsst/log.git
 base: https://github.com/lsst/base.git


### PR DESCRIPTION
It turns out that obs_cfht has a dependency on a repo of test data.
I don't think we want to make lsst_apps depend on yet another data
repo, so I'm removing obs_cfht