### PR TITLE
Added pandas to the list of required conda packages

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -51,7 +51,7 @@ test -f "$LSSTSW/miniconda/.deployed" || ( # Anaconda
         #       or they crept in by accident.
 
         export PATH="$LSSTSW/miniconda/bin:$PATH"
-        conda install --yes numpy scipy matplotlib requests cython sqlalchemy astropy
+        conda install --yes numpy scipy matplotlib requests cython sqlalchemy astropy pandas
         pip install stsci.distutils
     )
 


### PR DESCRIPTION
Sims would like to add pandas to the list of packages available to jenkins. 
We will add pandas to the list of packages required by users (most of which will already have pandas because of having anaconda from newinstall.sh).