### PR TITLE
no longer use install_name_tool to change load addresses

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -36,15 +36,6 @@ test -f "$LSSTSW/miniconda/.deployed" || ( # Anaconda
     curl -# -L -O http://repo.continuum.io/miniconda/${miniconda_file_name}
     bash ${miniconda_file_name} -b -p "$LSSTSW/miniconda"
 
-    if [[ $(uname -s) = Darwin* ]]; then
-        #run install_name_tool on all of the libpythonX.X.dylib dynamic
-        #libraries in miniconda
-        for entry in $LSSTSW/miniconda/lib/libpython*.dylib
-            do
-                install_name_tool -id $entry $entry
-            done
-    fi
-
     (
         # Install packages on which the stack is know to depend
         # Note: it's not clear if agreement was reached to use all of these,


### PR DESCRIPTION
In the past, we have dealt with GalSim's inability to find anaconda's libpython2.7.dylib when building on a Mac by using install_name_tool to change the load address of libpython2.7.dylib after it is built by lsstsw's deploy script.  This change is not robust against users running conda update on their python installation (in which case, the load address can be reverted to its default value, which GalSim cannot find).  Recent changes to the EUPS GalSim package mean that we are now using install_name_tool to temporarily change the load addresses while GalSim is being built, and then reverting those changes after the build is complete.  The present pull request removes the use of install_name_tool from lsstsw's deploy script, as it is no longer needed.