### PR TITLE
Update default EUPS version to 2.0.1

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -6,7 +6,7 @@
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 source ${SCRIPT_DIR}/../etc/settings.cfg.sh
 
-EUPS_VERSION=${EUPS_VERSION:-1.5.9}         # Version of EUPS to install
+EUPS_VERSION=${EUPS_VERSION:-2.0.1}         # Version of EUPS to install
 MINICONDA_VERSION=${MINICONDA_VERSION:-latest} # Version of Miniconda to install
 GIT_VERSION=${GIT_VERSION:-2.2.2}           # Version of git to install
 LFS_VERSION=${LFS_VERSION:-1.0.2}           # Version of git-lfs to install


### PR DESCRIPTION
Needed to get python 3 support and also to fix OS X El Capitan.