### PR TITLE
Do not create testdata_subaru package.

### DIFF
--- a/etc/manifest.remap
+++ b/etc/manifest.remap
@@ -1,1 +1,2 @@
 [create]afwdata              None
+[create]testdata_subaru      None


### PR DESCRIPTION
This package, like afwdata, is used for testing and CI, but not for everyday
usage. It's also large, and users shouldn't be required to download it to
installe the stack. Further, eups distrib doesn't currently handle git lfs, so
this won't actually provide any useful content anyway.