### PR TITLE
Mark ci_hsc as git-lfs.

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -224,4 +224,6 @@ validation_data_decam:
   lfs: true
 pyyaml: https://github.com/lsst/pyyaml.git
 requests: https://github.com/lsst/requests.git
-ci_hsc: https://github.com/lsst/ci_hsc
+ci_hsc:
+  url: https://github.com/lsst/ci_hsc.git
+  lfs: true


### PR DESCRIPTION
Originally just listed ci_hsc as a simple repo.  Forgot that I needed to list it as a git-lfs enabled repo.  This commit adds that.