### PR TITLE
    disable conda install progress bar when there is no tty

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -102,13 +102,25 @@ test -f "$LSSTSW/miniconda/.packages.deployed" || ( # conda packages
     # uses the conda package specification from this repo.
     export PATH="$LSSTSW/miniconda/bin:$PATH"
 
+    ARGS=()
+    ARGS+=("install" "--yes")
+
+    # disable the conda install progress bar when not attached to a tty. Eg.,
+    # when running under CI
+    if [[ $(tty --quiet) ]]; then
+        ARGS+=("-q")
+    fi
+
     if [[ $BLEED_DEPLOY == true ]]; then
         # The conda Intel MKL linked packages are intentionally avoided.
         # See: https://jira.lsstcorp.org/browse/DM-5105
-        conda install --yes nomkl numpy scipy matplotlib requests cython sqlalchemy astropy pandas future
+        CONDA_BLEED_PACKAGES=(nomkl numpy scipy matplotlib requests cython sqlalchemy astropy pandas future)
+        ARGS+=("${CONDA_BLEED_PACKAGES[@]}")
     else
-        conda install --yes --file "${SCRIPT_DIR}/../etc/${CONDA_PACKAGES}"
+        ARGS+=("--file" "${SCRIPT_DIR}/../etc/${CONDA_PACKAGES}")
     fi
+
+    conda "${ARGS[@]}"
 
     touch "$LSSTSW/miniconda/.packages.deployed"
 )


### PR DESCRIPTION
The package installation progress bar is causing 'scroll shock' in the
travis/jenkins output logs.