### PR TITLE
Stop masking healpy and scipy packages

### DIFF
--- a/etc/exclusions.txt
+++ b/etc/exclusions.txt
@@ -3,6 +3,4 @@
 
 cuda_toolkit            .*
 cuda_sdk                .*
-scipy                   .*
-healpy                  .*
 condor                  .*


### PR DESCRIPTION
The healpy and scipy packages build fine. No reason to mask them any more.