### PR TITLE
setup.csh now works like other setup files

### DIFF
--- a/bin/setup.csh
+++ b/bin/setup.csh
@@ -1,9 +1,27 @@
 # setup lsstsw environment
 #
-# source this file from your location of <lsstsw>
+# source this file from your ~/.cshrc
 #
-# relative to <lsstsw>/bin/
-setenv LSSTSW `pwd`
+# possibly blank, but can't be parsed as $_
+set cmd=($_)
+if ( $?0 ) then
+    set source=$0
+else if ( $#cmd >= 3 ) then
+    set source=`pwd`/${cmd[2]}
+else if (-f /usr/sbin/lsof ) then
+    set source=`/usr/sbin/lsof +p $$ | grep -oE /.\*setup.csh`
+endif
+
+if ( $?source ) then
+    set LSSTSW=`dirname $source`
+    set LSSTSW=`dirname $LSSTSW`
+endif
+
+if ( ! $?LSSTSW ) then
+    echo "error: could not figure out LSSTSW directory"
+    echo '  you can specify the directory by setting $LSSTW in your ~/.cshrc'
+    exit 1
+endif
 
 if ( ! -f $LSSTSW/eups/current/bin/setups.csh ) then
     echo "error: eups not found in $LSSTSW/eups/current" 1>&2

--- a/bin/setup.csh
+++ b/bin/setup.csh
@@ -8,7 +8,7 @@ setenv LSSTSW `pwd`
 if ( ! -f $LSSTSW/eups/current/bin/setups.csh ) then
     echo "error: eups not found in $LSSTSW/eups/current" 1>&2
     echo "  you may need to [re]run bin/deploy to [re]deploy EUPS." 1>&2
-    return
+    exit 1
 endif
 
 setenv PATH "$LSSTSW/miniconda/bin:$PATH"


### PR DESCRIPTION
`setup.csh` can now be sourced from login shell scripts and will set up lsstsw correctly. Support for directly sourcing the script has been kept for backward-compatibility with existing development environments.

@djreiss, can you confirm that your preferred way of executing the script still works?

Note to admins: I know forking is against LSST policy, but my account hasn't been added to the LSST organization yet. Apologies for the (hopefully) one-time violation!