### PR TITLE
DM-7676: lsof used by setup.csh not always in /usr/sbin

### DIFF
--- a/bin/setup.csh
+++ b/bin/setup.csh
@@ -2,16 +2,20 @@
 #
 # source this file from your ~/.cshrc
 
-
 set cmd=($_)        # possibly blank, but can't be parsed as $_
+set nonPathLsof=/usr/sbin/lsof
+
 if ( $?0 ) then        # direct execution
     set source=$0
 else if ( $#cmd >= 3 ) then        # direct sourcing
     set source=${cmd[2]}
-else if (-f /usr/sbin/lsof ) then        # indirect sourcing
-    set source=`/usr/sbin/lsof +p $$ | grep -oE /.\*setup.csh`
+else if ({ (which lsof >& /dev/null) }) then        # indirect sourcing
+    set source=`lsof +p $$ | grep -oE /.\*setup.csh`
+else if (-f $nonPathLsof ) then        # as above; lsof not always on path
+    set source=`$nonPathLsof +p $$ | grep -oE /.\*setup.csh`
 endif
 unset cmd
+unset nonPathLsof
 
 if ( $?source ) then
     set LSSTSW=`dirname $source`

--- a/bin/setup.csh
+++ b/bin/setup.csh
@@ -17,6 +17,7 @@ if ( $?source ) then
     set LSSTSW=`dirname $source`
     set LSSTSW=`cd $LSSTSW/.. && pwd`
 endif
+unset source
 
 if ( ! $?LSSTSW ) then
     echo "error: could not figure out LSSTSW directory"


### PR DESCRIPTION
`setup.csh` has been modified to look for `lsof` on the path, falling back to hard-coded locations only if necessary. [The issue](https://jira.lsstcorp.org/browse/DM-7676) was reported on Ubuntu 14.04, but I have only tested the fix on Ubuntu 16.04.