### PR TITLE
Add obs_base (forked from daf_butlerUtils prior to rename)

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -167,6 +167,7 @@ swig: https://github.com/lsst/swig.git
 kazoo: https://github.com/lsst/kazoo.git
 sims_data: https://github.com/lsst/sims_data.git
 daf_butlerUtils: https://github.com/lsst/daf_butlerUtils.git
+obs_base: https://github.com/lsst-dm/obs_base.git
 pyephem: https://github.com/lsst/pyephem.git
 ephem:  https://github.com/lsst/ephem.git
 ctrl_provenance: https://github.com/lsst/ctrl_provenance.git


### PR DESCRIPTION
In preparation for renaming daf_butlerUtils to obs_base, I've added the newly renamed fork. This will get updated again once it is moved back to github/lsst, from lsst-dm/.