### PR TITLE
Adding sims_survey_fields to repos.yaml

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -270,3 +270,4 @@ ctrl_stats: https://github.com/lsst/ctrl_stats.git
 starlink_ast:
   url: https://github.com/lsst/starlink_ast
   ref: lsst-dev
+sims_survey_fields: https://github.com/lsst/sims_survey_fields.git


### PR DESCRIPTION
I've tested this locally and it seems to work. BTW, the Travis builds seem to be broken on SSL connection to the Linux kernel site.