### PR TITLE
switch travis to trusty beta containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+dist: trusty
 sudo: false
+group: beta
 language: c
 matrix:
   include:


### PR DESCRIPTION
To work around curl failing to download git sources from kernel.org due
to not properly supporting the TLS cert.