### PR TITLE
DM-8296: Make fork of firefly_client installable by eups

### DIFF
--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -272,5 +272,7 @@ starlink_ast:
   url: https://github.com/lsst/starlink_ast
   ref: lsst-dev
 sims_survey_fields: https://github.com/lsst/sims_survey_fields.git
-firefly_client: https://github.com/lsst/firefly_client.git
+firefly_client: 
+  url: https://github.com/lsst/firefly_client.git
+  ref: lsst-dev
 ws4py: https://github.com/lsst/ws4py.git


### PR DESCRIPTION
Fix firefly_client repo with lsst-dev as ref

Put the Github url and the reference branch on separate lines, as for starlink_ast