### PR TITLE
DM-6058: Add numexpr and bottleneck to package list

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -112,7 +112,7 @@ test -f "$LSSTSW/miniconda/.packages.deployed" || ( # conda packages
     if [[ $BLEED_DEPLOY == true ]]; then
         PACKAGES=()
         # lsst_distrib / lsst_sims deps
-        PACKAGES+=(numpy scipy matplotlib requests cython sqlalchemy astropy pandas)
+        PACKAGES+=(numpy scipy matplotlib requests cython sqlalchemy astropy pandas numexpr bottleneck)
 
         # lsst_build deps
         PACKAGES+=(future pyyaml)

--- a/etc/conda2_packages-linux-64.txt
+++ b/etc/conda2_packages-linux-64.txt
@@ -21,6 +21,7 @@ libpng=1.6.27=0
 libxml2=2.9.4=0
 matplotlib=1.5.1=np111py27_0
 nomkl=1.0=0
+numexpr=2.6.0=np111py27_0
 numpy=1.11.2=py27_nomkl_0
 openblas=0.2.14=4
 openssl=1.0.2j=0

--- a/etc/conda2_packages-linux-64.txt
+++ b/etc/conda2_packages-linux-64.txt
@@ -2,6 +2,7 @@
 # $ conda create --name <env> --file <this file>
 # platform: linux-64
 astropy=1.2.1=np111py27_0
+bottleneck=1.2.0=np111py27_0
 cairo=1.14.6=0
 conda=4.2.13=py27_0
 conda-env=2.6.0=0

--- a/etc/conda2_packages-osx-64.txt
+++ b/etc/conda2_packages-osx-64.txt
@@ -13,6 +13,7 @@ future=0.16.0=py27_0
 libpng=1.6.22=0
 matplotlib=1.5.1=np111py27_0
 mkl=11.3.3=0
+numexpr=2.6.0=np111py27_0
 numpy=1.11.2=py27_0
 openssl=1.0.2j=0
 pandas=0.19.1=np111py27_0

--- a/etc/conda2_packages-osx-64.txt
+++ b/etc/conda2_packages-osx-64.txt
@@ -2,6 +2,7 @@
 # $ conda create --name <env> --file <this file>
 # platform: osx-64
 astropy=1.2.1=np111py27_0
+bottleneck=1.2.0=np111py27_0
 conda=4.2.13=py27_0
 conda-env=2.6.0=0
 cycler=0.10.0=py27_0

--- a/etc/conda3_packages-linux-64.txt
+++ b/etc/conda3_packages-linux-64.txt
@@ -20,6 +20,7 @@ libpng=1.6.27=0
 libxml2=2.9.4=0
 matplotlib=1.5.1=np111py35_0
 nomkl=1.0=0
+numexpr=2.6.0=np111py35_0
 numpy=1.11.2=py35_nomkl_0
 openblas=0.2.14=4
 openssl=1.0.2j=0

--- a/etc/conda3_packages-linux-64.txt
+++ b/etc/conda3_packages-linux-64.txt
@@ -2,6 +2,7 @@
 # $ conda create --name <env> --file <this file>
 # platform: linux-64
 astropy=1.2.1=np111py35_0
+bottleneck=1.2.0=np111py35_0
 cairo=1.14.6=0
 conda=4.2.13=py35_0
 conda-env=2.6.0=0

--- a/etc/conda3_packages-osx-64.txt
+++ b/etc/conda3_packages-osx-64.txt
@@ -12,6 +12,7 @@ future=0.16.0=py35_0
 libpng=1.6.22=0
 matplotlib=1.5.1=np111py35_0
 mkl=11.3.3=0
+numexpr=2.6.0=np111py35_0
 numpy=1.11.2=py35_0
 openssl=1.0.2j=0
 pandas=0.19.1=np111py35_0

--- a/etc/conda3_packages-osx-64.txt
+++ b/etc/conda3_packages-osx-64.txt
@@ -2,6 +2,7 @@
 # $ conda create --name <env> --file <this file>
 # platform: osx-64
 astropy=1.2.1=np111py35_0
+bottleneck=1.2.0=np111py35_0
 conda=4.2.13=py35_0
 conda-env=2.6.0=0
 cycler=0.10.0=py35_0

--- a/etc/conda_packages-linux-64.txt
+++ b/etc/conda_packages-linux-64.txt
@@ -21,6 +21,7 @@ libpng=1.6.27=0
 libxml2=2.9.4=0
 matplotlib=1.5.1=np111py27_0
 nomkl=1.0=0
+numexpr=2.6.0=np111py27_0
 numpy=1.11.2=py27_nomkl_0
 openblas=0.2.14=4
 openssl=1.0.2j=0

--- a/etc/conda_packages-linux-64.txt
+++ b/etc/conda_packages-linux-64.txt
@@ -2,6 +2,7 @@
 # $ conda create --name <env> --file <this file>
 # platform: linux-64
 astropy=1.2.1=np111py27_0
+bottleneck=1.2.0=np111py27_0
 cairo=1.14.6=0
 conda=4.2.13=py27_0
 conda-env=2.6.0=0

--- a/etc/conda_packages-osx-64.txt
+++ b/etc/conda_packages-osx-64.txt
@@ -13,6 +13,7 @@ future=0.16.0=py27_0
 libpng=1.6.22=0
 matplotlib=1.5.1=np111py27_0
 mkl=11.3.3=0
+numexpr=2.6.0=np111py27_0
 numpy=1.11.2=py27_0
 openssl=1.0.2j=0
 pandas=0.19.1=np111py27_0

--- a/etc/conda_packages-osx-64.txt
+++ b/etc/conda_packages-osx-64.txt
@@ -2,6 +2,7 @@
 # $ conda create --name <env> --file <this file>
 # platform: osx-64
 astropy=1.2.1=np111py27_0
+bottleneck=1.2.0=np111py27_0
 conda=4.2.13=py27_0
 conda-env=2.6.0=0
 cycler=0.10.0=py27_0

--- a/etc/repos.yaml
+++ b/etc/repos.yaml
@@ -131,6 +131,7 @@ cat: https://github.com/lsst/cat.git
 ip_isr: https://github.com/lsst/ip_isr.git
 pex_policy: https://github.com/lsst/pex_policy.git
 matplotlib: https://github.com/lsst/matplotlib.git
+pandas: https://github.com/lsst/pandas.git
 obs_sdss: https://github.com/lsst/obs_sdss.git
 activemqcpp: https://github.com/lsst/activemqcpp.git
 pex_harness: https://github.com/lsst-dm/legacy-pex_harness.git


### PR DESCRIPTION
Add numexpr and bottlenecks to the list of conda packages automatically installed by lsstsw.

Also: add the pandas EUPS stub to repos.yaml