### PR TITLE
cleanup conda lock files before bootstraping conda env

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -129,6 +129,11 @@ test -f "${LSSTSW}/miniconda/.packages.deployed" || ( # conda packages
     # shellcheck disable=SC2031
     export PATH="$LSSTSW/miniconda/bin:$PATH"
 
+    # conda may leave behind lock files from an uncompleted package
+    # installation attempt.  These need to be cleaned up before [re]attempting
+    # to install packages.
+    conda clean --lock
+
     ARGS=()
     ARGS+=("install" "--yes")
 


### PR DESCRIPTION
This failure mode has been encountered when re-running deploy after an
unsuccessful installation attempt.

    LockError: Lock error: Already locked: Lock error:
    LOCKERROR: It looks like conda is already doing something.
    The lock [u'.../lsstsw/miniconda/pkgs/mkl-11.3.3-0.tar.bz2.pid86953.conda_lock'] was found. Wait for it to finish before continuing.
    If you are sure that conda is not running, remove it and try again.