### PR TITLE
add BUILD#/bNNNN "provenience" to published eups distrib tags

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -120,12 +120,16 @@ run eups distrib declare --server-dir="$EUPS_PKGROOT" -t "$BUILD"
 
 if [[ ! -z $DISTRIBTAG && "$DISTRIBTAG" != "$BUILD" ]]; then
   echo "Adding tag '$DISTRIBTAG' at the distribution server."
-  run sed -r 's|EUPS distribution [^ ]+ version list. Version 1.0|EUPS distribution '"$DISTRIBTAG"' version list. Version 1.0|' \
-      "${EUPS_PKGROOT}/tags/${BUILD}.list" > "${EUPS_PKGROOT}/tags/${DISTRIBTAG}.list"
+
+  match='EUPS distribution ([^ ]+) version list. Version 1.0'
+  sub="EUPS distribution ${DISTRIBTAG} version list. Version 1.0\n#BUILD=\1"
+  src_tag="${EUPS_PKGROOT}/tags/${BUILD}.list"
+  dst_tag="${EUPS_PKGROOT}/tags/${DISTRIBTAG}.list"
+
+  run sed -r "s|${match}|${sub}|" "$src_tag" > "$dst_tag"
 
   # remove the original bNNNN tag to reduce tag proliferation
-  rm "${EUPS_PKGROOT}/tags/${BUILD}.list"
-
+  rm "$src_tag"
 fi
 
 #


### PR DESCRIPTION
Presently, external knowledge is required in order to relate a published eups
distrib tag with the corresponding versiondb manifest.  It greatly simplify the
task of verifying a past eups distrib tag if the BUILD#/bNNNN/manifest name
was embedded within the eups distrib tag list file.

As an example, this is the first few lines of the `w_2018_18` tag:

```
EUPS distribution w_2018_18 version list. Version 1.0
#product             flavor     version
#--------------------------------------
afw                  generic    15.0-24-g02ed2a30c+1
```

Which was generated from the `b3595` build produced by `lsst-build`.  This is
association can currently only be determined by inspecting the jenkins
`release/weekly-release` build metadata.  The first few lines of the `b3595`
manifest are:

```
# product                 SHA1                                      Version                       
BUILD=b3595
eigen                     8975fe89fd38377033bee504d32c695b077da748  3.2.5.lsst3
```

With the changes in this PR, first few lines of `w_2018_18` would have been:

```
EUPS distribution w_2018_18 version list. Version 1.0
#BUILD=b3595
#product             flavor     version
#--------------------------------------
afw                  generic    15.0-24-g02ed2a30c+1
```

The new bNNNN reference is as a comment line, and should be ignored by existing
tools, while also attempting to follow the format of the manifest as closely as
is possible.