### PR TITLE
add conda "bleed" mode environment files

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -10,7 +10,9 @@ source "${SCRIPT_DIR}/../etc/settings.cfg.sh"
 EUPS_VERSION=${EUPS_VERSION:-2.1.4}         # Version of EUPS to install
 EUPS_GITREV=${EUPS_GITREV:-""}
 EUPS_GITREPO=${EUPS_GITREPO:-https://github.com/RobertLuptonTheGood/eups.git}
-MINICONDA3_VERSION=${MINICONDA3_VERSION:-4.3.21} # Version of Miniconda to install
+# force Python 3
+LSST_PYTHON_VERSION=3
+MINICONDA_VERSION=${MINICONDA_VERSION:-4.3.21}
 MINICONDA_BASE_URL=${MINICONDA_BASE_URL:-https://repo.continuum.io/miniconda}
 CONDA_CHANNELS=${CONDA_CHANNELS:-""}
 GIT_VERSION=${GIT_VERSION:-2.16.1}          # Version of git to install
@@ -138,8 +140,8 @@ main() {
   export PATH="${LSSTSW}/lfs/bin:${PATH}"
   export PATH="${LSSTSW}/bin:${PATH}"
 
-  local pyver_prefix=3
-  local miniconda_version=$MINICONDA3_VERSION
+  local pyver_prefix=$LSST_PYTHON_VERSION
+  local miniconda_version=$MINICONDA_VERSION
 
   local deploy_mode=packages
   if [[ $BLEED_DEPLOY == true ]]; then

--- a/bin/deploy
+++ b/bin/deploy
@@ -207,7 +207,11 @@ main() {
     fi
   )
 
-  test -f "${LSSTSW}/miniconda/.packages.deployed" || ( # conda packages
+  # cleanup orphaned lock file
+  local old_miniconda_pkgs_lock="${LSSTSW}/miniconda/.packages.deployed"
+  [[ -e $old_miniconda_pkgs_lock ]] && rm "$old_miniconda_pkgs_lock"
+
+  (
     # Install packages on which the stack is known to depend
 
     # XXX note that
@@ -234,8 +238,6 @@ main() {
     ARGS+=("--file" "${SCRIPT_DIR}/../etc/${conda_packages}")
 
     conda "${ARGS[@]}"
-
-    touch "${LSSTSW}/miniconda/.packages.deployed"
   )
 
   # intentionally outside of a lockfile subshell

--- a/bin/deploy
+++ b/bin/deploy
@@ -186,12 +186,12 @@ main() {
     touch "$miniconda_lock"
   )
 
+  # intentionally outside of a lockfile subshell
+  export PATH="$LSSTSW/miniconda/bin:$PATH"
+
   (
     # configure alt conda channel(s)
     if [[ -n $CONDA_CHANNELS ]]; then
-      # shellcheck disable=SC2030
-      export PATH="$LSSTSW/miniconda/bin:$PATH"
-
       # remove any previously configured non-default channels
       # XXX allowed to fail
       conda config --remove-key channels || true
@@ -218,7 +218,6 @@ main() {
     # https://github.com/lsst/miniconda2/blob/master/ups/eupspkg.cfg.sh
     # uses the conda package specification from this repo.
     # shellcheck disable=SC2031
-    export PATH="$LSSTSW/miniconda/bin:$PATH"
 
     # conda may leave behind lock files from an uncompleted package
     # installation attempt.  These need to be cleaned up before [re]attempting

--- a/bin/deploy
+++ b/bin/deploy
@@ -141,19 +141,27 @@ main() {
   local pyver_prefix=3
   local miniconda_version=$MINICONDA3_VERSION
 
+  local deploy_mode=packages
+  if [[ $BLEED_DEPLOY == true ]]; then
+    deploy_mode=bleed
+  fi
+
   case $(uname -s) in
     Linux*)
-      local ana_platform="Linux-x86_64"
-      local conda_packages="conda${pyver_prefix}_packages-linux-64.txt"
+      local ana_platform='Linux-x86_64'
+      local pkg_postfix='linux-64'
       ;;
     Darwin*)
-      local ana_platform="MacOSX-x86_64"
-      local conda_packages="conda${pyver_prefix}_packages-osx-64.txt"
+      local ana_platform='MacOSX-x86_64'
+      local pkg_postfix='osx-64'
       ;;
     *)
       fail "Cannot install miniconda: unsupported platform $(uname -s)"
       ;;
   esac
+
+  local conda_packages
+  conda_packages="conda${pyver_prefix}_${deploy_mode}-${pkg_postfix}.txt"
 
   cd "$LSSTSW"
 
@@ -214,7 +222,8 @@ main() {
     conda clean --lock
 
     ARGS=()
-    ARGS+=("install" "--yes")
+    ARGS+=('env' 'update')
+    ARGS+=('--name' "$LSST_CONDA_ENV_NAME")
 
     # disable the conda install progress bar when not attached to a tty. Eg.,
     # when running under CI
@@ -222,32 +231,16 @@ main() {
       ARGS+=("-q")
     fi
 
-    if [[ $BLEED_DEPLOY == true ]]; then
-      PACKAGES=()
-      # lsst_distrib / lsst_sims deps
-      PACKAGES+=(numpy scipy matplotlib requests cython sqlalchemy astropy pandas numexpr bottleneck h5py)
-
-      # lsst_build deps
-      PACKAGES+=(future pyyaml)
-
-      # The conda Intel MKL linked packages are intentionally avoided [on
-      # linux].
-      # See: https://jira.lsstcorp.org/browse/DM-5105
-      if [[ $(uname -s) == Linux* ]]; then
-        PACKAGES+=("nomkl")
-      fi
-
-      # filter duplicate packages
-      PACKAGES=($(echo "${PACKAGES[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
-      ARGS+=("${PACKAGES[@]}")
-    else
-      ARGS+=("--file" "${SCRIPT_DIR}/../etc/${conda_packages}")
-    fi
+    ARGS+=("--file" "${SCRIPT_DIR}/../etc/${conda_packages}")
 
     conda "${ARGS[@]}"
 
     touch "${LSSTSW}/miniconda/.packages.deployed"
   )
+
+  # intentionally outside of a lockfile subshell
+  # shellcheck disable=SC1091
+  source activate "$LSST_CONDA_ENV_NAME"
 
   test -f "${LSSTSW}/lfs/.git.deployed" || ( # git
     if hash git 2>/dev/null; then

--- a/bin/publish
+++ b/bin/publish
@@ -75,6 +75,9 @@ fi
 
 PRODUCTS=("$@")
 
+# shellcheck disable=SC1091
+source activate "$LSST_CONDA_ENV_NAME"
+
 for prod in "${PRODUCTS[@]}"; do
   if [[ -z "$prod" ]]; then
     echo "zero length product names are not permitted"

--- a/bin/rebuild
+++ b/bin/rebuild
@@ -64,6 +64,9 @@ if [[ "$#" != "0" ]]; then
 fi
 
 (
+  # shellcheck disable=SC1091
+  source activate "$LSST_CONDA_ENV_NAME"
+
   # true if `lsst-build prepare` has run successfully
   PREPARED=false
 

--- a/bin/setup.csh
+++ b/bin/setup.csh
@@ -42,6 +42,12 @@ rehash
 
 setenv MANPATH "$LSSTSW/lfs/share/man:"
 
+if ( ! $?LSST_CONDA_ENV_NAME ) then
+  set LSST_CONDA_ENV_NAME="lsst-dm-scipipe"
+endif
+# shellcheck disable=SC1091
+source activate "$LSST_CONDA_ENV_NAME"
+
 source "$LSSTSW/eups/current/bin/setups.csh"
 
 setup -r "$LSSTSW/lsst_build"

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -25,6 +25,10 @@ export PATH="$LSSTSW/bin:$PATH"
 
 export MANPATH="$LSSTSW/lfs/share/man:"
 
+LSST_CONDA_ENV_NAME=${LSST_CONDA_ENV_NAME:-lsst-dm-scipipe}
+# shellcheck disable=SC1091
+source activate "$LSST_CONDA_ENV_NAME"
+
 # shellcheck disable=SC1090
 . "$LSSTSW/eups/current/bin/setups.$SUFFIX"
 

--- a/etc/conda3_bleed-linux-64.txt
+++ b/etc/conda3_bleed-linux-64.txt
@@ -1,19 +1,15 @@
-name: lsst-dm-scipipe
-channels:
-  - defaults
-dependencies:
-  - astropy
-  - bottleneck
-  - cython
-  - future
-  - h5py
-  - matplotlib
-  - nomkl
-  - numexpr
-  - numpy
-  - pandas
-  - pip
-  - pyyaml
-  - requests
-  - scipy
-  - sqlalchemy
+astropy
+bottleneck
+cython
+future
+h5py
+matplotlib
+nomkl
+numexpr
+numpy
+pandas
+pip
+pyyaml
+requests
+scipy
+sqlalchemy

--- a/etc/conda3_bleed-linux-64.txt
+++ b/etc/conda3_bleed-linux-64.txt
@@ -1,12 +1,13 @@
 # This env file should be kept in sync with conda3_bleed-osx-64.txt with the
 # exception of the nomkl being present on linux and NOT on osx.
+# nomkl is required on linux.  See DM-8146
+# future + pyyaml are lsst-build deps. See DM-15025
 astropy
 bottleneck
 cython
 future
 h5py
 matplotlib
-# nomkl is required on linux.  See DM-8146
 nomkl
 numexpr
 numpy

--- a/etc/conda3_bleed-linux-64.txt
+++ b/etc/conda3_bleed-linux-64.txt
@@ -1,0 +1,19 @@
+name: lsst-dm-scipipe
+channels:
+  - defaults
+dependencies:
+  - astropy
+  - bottleneck
+  - cython
+  - future
+  - h5py
+  - matplotlib
+  - nomkl
+  - numexpr
+  - numpy
+  - pandas
+  - pip
+  - pyyaml
+  - requests
+  - scipy
+  - sqlalchemy

--- a/etc/conda3_bleed-linux-64.txt
+++ b/etc/conda3_bleed-linux-64.txt
@@ -1,9 +1,12 @@
+# This env file should be kept in sync with conda3_bleed-osx-64.txt with the
+# exception of the nomkl being present on linux and NOT on osx.
 astropy
 bottleneck
 cython
 future
 h5py
 matplotlib
+# nomkl is required on linux.  See DM-8146
 nomkl
 numexpr
 numpy

--- a/etc/conda3_bleed-osx-64.txt
+++ b/etc/conda3_bleed-osx-64.txt
@@ -1,0 +1,18 @@
+name: lsst-dm-scipipe
+channels:
+  - defaults
+dependencies:
+  - astropy
+  - bottleneck
+  - cython
+  - future
+  - h5py
+  - matplotlib
+  - numexpr
+  - numpy
+  - pandas
+  - pip
+  - pyyaml
+  - requests
+  - scipy
+  - sqlalchemy

--- a/etc/conda3_bleed-osx-64.txt
+++ b/etc/conda3_bleed-osx-64.txt
@@ -1,5 +1,7 @@
 # This env file should be kept in sync with conda3_bleed-linux-64.txt with the
 # exception of the nomkl being present on linux and NOT on osx.
+# nomkl is required on linux.  See DM-8146
+# future + pyyaml are lsst-build deps. See DM-15025
 astropy
 bottleneck
 cython

--- a/etc/conda3_bleed-osx-64.txt
+++ b/etc/conda3_bleed-osx-64.txt
@@ -1,18 +1,14 @@
-name: lsst-dm-scipipe
-channels:
-  - defaults
-dependencies:
-  - astropy
-  - bottleneck
-  - cython
-  - future
-  - h5py
-  - matplotlib
-  - numexpr
-  - numpy
-  - pandas
-  - pip
-  - pyyaml
-  - requests
-  - scipy
-  - sqlalchemy
+astropy
+bottleneck
+cython
+future
+h5py
+matplotlib
+numexpr
+numpy
+pandas
+pip
+pyyaml
+requests
+scipy
+sqlalchemy

--- a/etc/conda3_bleed-osx-64.txt
+++ b/etc/conda3_bleed-osx-64.txt
@@ -1,3 +1,5 @@
+# This env file should be kept in sync with conda3_bleed-linux-64.txt with the
+# exception of the nomkl being present on linux and NOT on osx.
 astropy
 bottleneck
 cython

--- a/etc/settings.cfg.sh
+++ b/etc/settings.cfg.sh
@@ -34,6 +34,9 @@ VERSIONDB=${LSSTSW}/versiondb
 # location of exclusions.txt file for 'lsst-build prepare' command
 EXCLUSIONS=${LSSTSW}/etc/exclusions.txt
 
+# name of conda env to create/update/use
+LSST_CONDA_ENV_NAME=${LSST_CONDA_ENV_NAME:-lsst-dm-scipipe}
+
 #
 # exported variables
 #


### PR DESCRIPTION
Separates the conda package "data" from the deploy "code" so that the canonical "bleed" package list may be modified without touching "code".

based on #220 