### PR TITLE
travis improvements

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,8 @@
+---
+ignored:
+  # disable USER root
+  - DL3002
+  # disable pinning apk package versions
+  - DL3018
+  # disable following sourced files
+  - SC1091

--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -1,0 +1,7 @@
+# https://github.com/markdownlint/markdownlint/blob/master/docs/creating_styles.md
+# https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+all
+rule "MD013", :code_blocks => false
+exclude_rule "MD003"
+exclude_rule "MD034"
+exclude_rule "MD036"

--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -3,5 +3,6 @@
 all
 rule "MD013", :code_blocks => false
 exclude_rule "MD003"
+exclude_rule "MD013"
 exclude_rule "MD034"
 exclude_rule "MD036"

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,5 @@
+# a seperate "style" file must be used to pass "parameters" to a rule
+#
+# https://github.com/markdownlint/markdownlint/blob/master/docs/configuration.md
+# https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+style ".mdl_style.rb"

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,4 +1,4 @@
-# a seperate "style" file must be used to pass "parameters" to a rule
+# a separate "style" file must be used to pass "parameters" to a rule
 #
 # https://github.com/markdownlint/markdownlint/blob/master/docs/configuration.md
 # https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 sudo: false
 language: c
 matrix:
@@ -6,20 +7,27 @@ matrix:
       env:
         - MODE=versiondb
         - VERSIONDB_PUSH=true
+
     - os: linux
       env:
         - MODE=versiondb
         - VERSIONDB_PUSH=false
+
     - os: linux
       env: MODE=deploy3
+
     - os: linux
       env: MODE=deploy3-bleed
+
     #- os: osx
     #  env: MODE=deploy3
+
     #- os: osx
     #  env: MODE=deploy3-bleed
+
     - os: linux
       env: MODE=redeploy
+
     - env: TEST=shellcheck
       services:
         - docker
@@ -174,5 +182,7 @@ script: |
 branches:
   only:
     - master
+    # also matched against tag pushes
+    - /^\d+\.\d+\.\d+$/
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,26 +7,33 @@ matrix:
       env:
         - MODE=versiondb
         - VERSIONDB_PUSH=true
+      script: ./tests/acceptance.sh
 
     - os: linux
       env:
         - MODE=versiondb
         - VERSIONDB_PUSH=false
+      script: ./tests/acceptance.sh
 
     - os: linux
       env: MODE=deploy3
+      script: ./tests/acceptance.sh
 
     - os: linux
       env: MODE=deploy3-bleed
+      script: ./tests/acceptance.sh
 
     #- os: osx
     #  env: MODE=deploy3
+    #  script: ./tests/acceptance.sh
 
     #- os: osx
     #  env: MODE=deploy3-bleed
+    #  script: ./tests/acceptance.sh
 
     - os: linux
       env: MODE=redeploy
+      script: ./tests/acceptance.sh
 
     - env: TEST=markdownlint
       language: c
@@ -49,137 +56,6 @@ matrix:
   fast_finish: true
   #allow_failures:
   #  - os: osx
-script: |
-  set -e
-  export SHELLOPTS
-
-  expect() {
-    local title="$1"
-    local is="$2"
-    local should="$3"
-
-    echo -e "$title"
-
-    if [[ "$is" != "$should" ]]; then
-       echo -e "    expected(${should})"
-       echo -e "    got(${is})"
-       exit 1
-    fi
-  }
-
-  case $MODE in
-    deploy*)
-      # print git version
-      git --version
-      if [[ $MODE == deploy3-bleed ]]; then
-        echo -e "*** testing with BLEED Python 3 conda/pip packages ***\n"
-        ./bin/deploy -b
-      elif [[ $MODE == deploy3 ]]; then
-        echo -e "*** testing with PINNED Python 3 conda/pip packages ***\n"
-        ./bin/deploy
-      else
-        echo -e "*** Unrecognized mode for deploy script ***\n"
-        exit -1
-      fi
-      . ./bin/setup.sh
-      case $(uname -s) in
-        Linux*)
-          conda_packages="conda3_packages-linux-64.txt"
-          ;;
-        Darwin*)
-          conda_packages="conda3_packages-osx-64.txt"
-          ;;
-        *)
-          echo "unsupported platform $(uname -s)"
-          exit 1
-          ;;
-      esac
-      echo -e "*** checking installed vs ${conda_packages} conda packages ***\n"
-      conda list -e > "./etc/${conda_packages}"
-      git diff
-      rebuild pytest
-      ;;
-    versiondb*)
-      echo -e "*** testing VERSIONDB_PUSH=$VERSIONDB_PUSH for versiondb ***\n"
-      export VERSIONDB_PUSH
-      export VERSIONDB_REPO=./versiondb-test
-      mkdir -p $VERSIONDB_REPO
-      (cd $VERSIONDB_REPO; git init --bare)
-      # pull will fail unless there is a master ref to actually pull; so we
-      # make one
-      (
-        tmpdir=$(mktemp -u -t 'versiondb.XXXXXXXX')
-        trap "{ rm -rf $tmpdir; }" EXIT
-
-        mkdir -p "$tmpdir"
-        git clone "$VERSIONDB_REPO" "$tmpdir"
-        cd $tmpdir
-        # it appears that with some versions of git, --author doesn't bypass
-        # the user.email/user.name check.
-        git config --local user.email 'author@example.com'
-        git config --local user.name 'A U Thor'
-        git commit --allow-empty -m 'initial commit' --author='A U Thor <author@example.com>'
-        git push origin master
-      )
-
-      ./bin/deploy
-
-      mkdir -p versiondb/{dep_db,ver_db,manifests}
-
-      . ./bin/setup.sh
-      rebuild pytest
-
-      cd $VERSIONDB_REPO
-      if [[ $VERSIONDB_PUSH == true ]]; then
-        echo 'should have master ref'
-        git show-ref --heads | grep -q refs/heads/master
-
-        revs=($(git rev-list master))
-
-        # the first commit is the garbage empty commit in order to create the
-        # master ref
-        expect 'should have two commits'\
-          ${#revs[@]} \
-          2
-
-        expect 'should have author name' \
-          "$(git log --format=%an ${revs[0]}^\!)" \
-          'LSST DATA Management'
-
-        expect 'should have author email' \
-          "$(git log --format=%ae ${revs[0]}^\!)" \
-          'dm-devel@lists.lsst.org'
-
-        expect 'should have subject line' \
-          "$(git log --format=%s ${revs[0]}^\!)" \
-          'Updates for build b1.'
-      else
-        echo 'should have master ref'
-        git show-ref --heads | grep -q refs/heads/master
-
-        revs=($(git rev-list master))
-        expect 'should have one commit' \
-          ${#revs[@]} \
-          1
-      fi
-      ;;
-    redeploy)
-      ./bin/deploy
-
-      set -x
-      echo 'check lsst_build update works when a hash is specified'
-      current_hash=$(cd lsst_build; git log -n 1 --pretty=format:'%H')
-      LSST_BUILD_GITREV="$current_hash" ./bin/deploy
-
-      echo 'check lsst_build update works when a branch name is specified'
-      LSST_BUILD_GITREV='master' ./bin/deploy
-      set +x
-      ;;
-    *)
-      echo "unknown MODE: $MODE"
-      exit 1
-      ;;
-  esac
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,10 @@ matrix:
       services:
         - docker
       script: ./tests/hadolint.sh
+
+    - env: TEST=make
+      language: c
+      script: ./tests/make.sh
   # osx builds are often very slow to start due to high demand
   fast_finish: true
   # allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,37 +3,36 @@ sudo: false
 language: c
 matrix:
   include:
-    - os: linux
+    - &accept
+      os: linux
+      env: MODE=deploy3
+      services:
+        - docker
+      script: ./tests/docker-acceptance.sh
+
+    - <<: *accept
+      env: MODE=deploy3-bleed
+
+    - <<: *accept
+      env: MODE=redeploy
+
+    - <<: *accept
       env:
         - MODE=versiondb
         - VERSIONDB_PUSH=true
-      script: ./tests/acceptance.sh
 
-    - os: linux
+    - <<: *accept
       env:
         - MODE=versiondb
         - VERSIONDB_PUSH=false
-      script: ./tests/acceptance.sh
 
-    - os: linux
-      env: MODE=deploy3
-      script: ./tests/acceptance.sh
+    # - os: osx
+    #   env: MODE=deploy3
+    #   script: ./tests/acceptance.sh
 
-    - os: linux
-      env: MODE=deploy3-bleed
-      script: ./tests/acceptance.sh
-
-    #- os: osx
-    #  env: MODE=deploy3
-    #  script: ./tests/acceptance.sh
-
-    #- os: osx
-    #  env: MODE=deploy3-bleed
-    #  script: ./tests/acceptance.sh
-
-    - os: linux
-      env: MODE=redeploy
-      script: ./tests/acceptance.sh
+    # - os: osx
+    #   env: MODE=deploy3-bleed
+    #   script: ./tests/acceptance.sh
 
     - env: TEST=markdownlint
       language: c
@@ -54,8 +53,8 @@ matrix:
       script: ./tests/shellcheck.sh
   # osx builds are often very slow to start due to high demand
   fast_finish: true
-  #allow_failures:
-  #  - os: osx
+  # allow_failures:
+  #   - os: osx
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,12 @@ matrix:
       services:
         - docker
       script: ./tests/shellcheck.sh
+
+    - env: TEST=hadolint
+      language: c
+      services:
+        - docker
+      script: ./tests/hadolint.sh
   # osx builds are often very slow to start due to high demand
   fast_finish: true
   # allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,12 @@ matrix:
     - os: linux
       env: MODE=redeploy
 
+    - env: TEST=markdownlint
+      language: c
+      services:
+        - docker
+      script: ./tests/mdl.sh
+
     - env: TEST=yamllint
       language: c
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,11 +73,9 @@ script: |
       git --version
       if [[ $MODE == deploy3-bleed ]]; then
         echo -e "*** testing with BLEED Python 3 conda/pip packages ***\n"
-        CONDA_PREFIX="3"
         ./bin/deploy -b
       elif [[ $MODE == deploy3 ]]; then
         echo -e "*** testing with PINNED Python 3 conda/pip packages ***\n"
-        CONDA_PREFIX="3"
         ./bin/deploy
       else
         echo -e "*** Unrecognized mode for deploy script ***\n"
@@ -86,10 +84,10 @@ script: |
       . ./bin/setup.sh
       case $(uname -s) in
         Linux*)
-          conda_packages="conda${CONDA_PREFIX}_packages-linux-64.txt"
+          conda_packages="conda3_packages-linux-64.txt"
           ;;
         Darwin*)
-          conda_packages="conda${CONDA_PREFIX}_packages-osx-64.txt"
+          conda_packages="conda3_packages-osx-64.txt"
           ;;
         *)
           echo "unsupported platform $(uname -s)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,32 +34,26 @@ matrix:
     #   env: MODE=deploy3-bleed
     #   script: ./tests/acceptance.sh
 
-    - env: TEST=markdownlint
+    - &plumb
+      env: TEST=markdownlint
       language: c
       services:
         - docker
       script: ./tests/mdl.sh
 
-    - env: TEST=yamllint
-      language: c
-      services:
-        - docker
+    - <<: *plumb
+      env: TEST=yamllint
       script: ./tests/yamllint.sh
 
-    - env: TEST=shellcheck
-      language: c
-      services:
-        - docker
+    - <<: *plumb
+      env: TEST=shellcheck
       script: ./tests/shellcheck.sh
 
-    - env: TEST=hadolint
-      language: c
-      services:
-        - docker
+    - <<: *plumb
+      env: TEST=hadolint
       script: ./tests/hadolint.sh
 
     - env: TEST=make
-      language: c
       script: ./tests/make.sh
   # osx builds are often very slow to start due to high demand
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,12 @@ matrix:
     - os: linux
       env: MODE=redeploy
 
+    - env: TEST=yamllint
+      language: c
+      services:
+        - docker
+      script: ./tests/yamllint.sh
+
     - env: TEST=shellcheck
       language: c
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,19 +29,10 @@ matrix:
       env: MODE=redeploy
 
     - env: TEST=shellcheck
+      language: c
       services:
         - docker
-      script: |
-        set -e
-        shopt -s globstar nullglob
-        CHECK=( **/*.sh bin/* )
-        IGNORE=( **/*.csh bin/flock-fd lsst_build/** )
-        for i in "${!CHECK[@]}"; do
-          [[ " ${IGNORE[@]} " =~ " ${CHECK[$i]} " ]] && unset -v 'CHECK[$i]'
-        done
-        [[ ${#CHECK[@]} -eq 0 ]] && exit
-        docker run -v $(pwd):$(pwd) -w $(pwd) \
-          koalaman/shellcheck-alpine:v0.4.6 -x "${CHECK[@]}"
+      script: ./tests/shellcheck.sh
   # osx builds are often very slow to start due to high demand
   fast_finish: true
   #allow_failures:

--- a/README.md
+++ b/README.md
@@ -14,20 +14,20 @@ http://developer.lsst.io/en/latest/build-ci/lsstsw.html
 Structure
 ---------
 
-path       | description
-:----------|:-----------------------------------------------------------------
-miniconda  | Anaconda Python distribution
-bin        | software distribution binaries (rebuild, publish)
-build      | directory where builds take place
-distserver | EUPS distribution server directory
-etc        | configuration files live here
-eups       | local installation of EUPS
-lfs        | local installation of various packages, e.g. git (lfs stands for "Linux from Scratch")
-lsst_build | lsst_build software tools directory (separately git managed)
-README     | the file you're reading
-stack      | the EUPS software stack into which successfully built packages are installed
-var        | contains lock files and log files
-versiondb  | version database used by lsst_build to assign +N versions (separately git managed)
+| path       | description                                                    |
+| :----------|:---------------------------------------------------------------|
+| miniconda  | Anaconda Python distribution                                   |
+| bin        | software distribution binaries (rebuild, publish)              |
+| build      | directory where builds take place                              |
+| distserver | EUPS distribution server directory                             |
+| etc        | configuration files live here                                  |
+| eups       | local installation of EUPS                                     |
+| lfs        | local installation of various packages, e.g. git (lfs stands for "Linux from Scratch") |
+| lsst_build | lsst_build software tools directory (separately git managed)   |
+| README     | the file you're reading                                        |
+| stack      | the EUPS software stack into which successfully built packages are installed |
+| var        | contains lock files and log files                              |
+| versiondb  | version database used by lsst_build to assign +N versions (separately git managed) |
 
 The most important directories to know about are etc (config files), stack
 (the built software directory), and distserver (the distribution server
@@ -44,7 +44,7 @@ Release workflow
 
 Typical release workflow:
 
-  * run `rebuild`, run acceptance checks until satisfied
-  * git-tag the packages using mass-tag with the release tag
-  * rerun `rebuild` with the tags
-  * run `publish current`
+* run `rebuild`, run acceptance checks until satisfied
+* git-tag the packages using mass-tag with the release tag
+* rerun `rebuild` with the tags
+* run `publish current`

--- a/bin/deploy
+++ b/bin/deploy
@@ -4,7 +4,7 @@
 #
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
-# shellcheck source=./etc/settings.cfg.sh
+# shellcheck disable=SC1090
 source "${SCRIPT_DIR}/../etc/settings.cfg.sh"
 
 EUPS_VERSION=${EUPS_VERSION:-2.1.4}         # Version of EUPS to install

--- a/bin/publish
+++ b/bin/publish
@@ -18,7 +18,7 @@ BUILD=
 
 set -e
 DIR=$(cd "$(dirname "$0")"; pwd)
-# shellcheck source=./etc/settings.cfg.sh
+# shellcheck disable=SC1090
 . "${DIR}/../etc/settings.cfg.sh"
 
 usage() { echo "Usage: $0 [-b <build_id>] [-t <distservtag>] <product1> [product2 [...]]" 1>&2; exit 1; }

--- a/bin/rebuild
+++ b/bin/rebuild
@@ -18,9 +18,9 @@
 
 set -e
 DIR=$(cd "$(dirname "$0")"; pwd)
-# shellcheck source=./etc/settings.cfg.sh
+# shellcheck disable=SC1090
 . "${DIR}/../etc/settings.cfg.sh"
-# shellcheck source=./bin/deploy
+# shellcheck disable=SC1090
 . "${DIR}/deploy"
 
 usage() { echo "Usage: $0 [-p] [-n] [-u] [-r <ref> [-r <ref2> [...]]] [-t <eupstag>] [product1 [product2 [...]]]" 1>&2; exit 1; }

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,17 @@
+FROM lsstsqre/centos:7-stackbase-devtoolset-6
+
+ARG     D_USER
+ARG     D_UID
+ARG     D_GROUP
+ARG     D_GID
+ARG     D_HOME
+
+USER    root
+RUN     mkdir -p "$(dirname "$D_HOME")"
+RUN     groupadd -g "$D_GID" "$D_GROUP"
+RUN     useradd -d "$D_HOME" -g "$D_GROUP" -u "$D_UID" "$D_USER"
+
+USER    $D_USER
+WORKDIR $D_HOME
+
+SHELL ["/bin/bash", "-lc"]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,10 @@
+docker:
+	docker build \
+		-t lsstsw-testenv\
+		--pull=true \
+		--build-arg D_USER="$(shell id -un)" \
+		--build-arg D_UID="$(shell id -u)" \
+		--build-arg D_GROUP="$(shell id -gn)" \
+		--build-arg D_GID="$(shell id -g)" \
+		--build-arg D_HOME="$(HOME)" \
+		.

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+set -eo pipefile
+export SHELLOPTS
+
+expect() {
+local title="$1"
+local is="$2"
+local should="$3"
+
+echo -e "$title"
+
+if [[ "$is" != "$should" ]]; then
+   echo -e "    expected(${should})"
+   echo -e "    got(${is})"
+   exit 1
+fi
+}
+
+case $MODE in
+deploy*)
+  # print git version
+  git --version
+  if [[ $MODE == deploy3-bleed ]]; then
+    echo -e "*** testing with BLEED Python 3 conda/pip packages ***\n"
+    ./bin/deploy -b
+  elif [[ $MODE == deploy3 ]]; then
+    echo -e "*** testing with PINNED Python 3 conda/pip packages ***\n"
+    ./bin/deploy
+  else
+    echo -e "*** Unrecognized mode for deploy script ***\n"
+    exit -1
+  fi
+  . ./bin/setup.sh
+  case $(uname -s) in
+    Linux*)
+      conda_packages="conda3_packages-linux-64.txt"
+      ;;
+    Darwin*)
+      conda_packages="conda3_packages-osx-64.txt"
+      ;;
+    *)
+      echo "unsupported platform $(uname -s)"
+      exit 1
+      ;;
+  esac
+  echo -e "*** checking installed vs ${conda_packages} conda packages ***\n"
+  conda list -e > "./etc/${conda_packages}"
+  git diff
+  rebuild pytest
+  ;;
+versiondb*)
+  echo -e "*** testing VERSIONDB_PUSH=$VERSIONDB_PUSH for versiondb ***\n"
+  export VERSIONDB_PUSH
+  export VERSIONDB_REPO=./versiondb-test
+  mkdir -p $VERSIONDB_REPO
+  (cd $VERSIONDB_REPO; git init --bare)
+  # pull will fail unless there is a master ref to actually pull; so we
+  # make one
+  (
+    tmpdir=$(mktemp -u -t 'versiondb.XXXXXXXX')
+    trap "{ rm -rf $tmpdir; }" EXIT
+
+    mkdir -p "$tmpdir"
+    git clone "$VERSIONDB_REPO" "$tmpdir"
+    cd $tmpdir
+    # it appears that with some versions of git, --author doesn't bypass
+    # the user.email/user.name check.
+    git config --local user.email 'author@example.com'
+    git config --local user.name 'A U Thor'
+    git commit --allow-empty -m 'initial commit' --author='A U Thor <author@example.com>'
+    git push origin master
+  )
+
+  ./bin/deploy
+
+  mkdir -p versiondb/{dep_db,ver_db,manifests}
+
+  . ./bin/setup.sh
+  rebuild pytest
+
+  cd $VERSIONDB_REPO
+  if [[ $VERSIONDB_PUSH == true ]]; then
+    echo 'should have master ref'
+    git show-ref --heads | grep -q refs/heads/master
+
+    revs=($(git rev-list master))
+
+    # the first commit is the garbage empty commit in order to create the
+    # master ref
+    expect 'should have two commits'\
+      ${#revs[@]} \
+      2
+
+    expect 'should have author name' \
+      "$(git log --format=%an ${revs[0]}^\!)" \
+      'LSST DATA Management'
+
+    expect 'should have author email' \
+      "$(git log --format=%ae ${revs[0]}^\!)" \
+      'dm-devel@lists.lsst.org'
+
+    expect 'should have subject line' \
+      "$(git log --format=%s ${revs[0]}^\!)" \
+      'Updates for build b1.'
+  else
+    echo 'should have master ref'
+    git show-ref --heads | grep -q refs/heads/master
+
+    revs=($(git rev-list master))
+    expect 'should have one commit' \
+      ${#revs[@]} \
+      1
+  fi
+  ;;
+redeploy)
+  ./bin/deploy
+
+  set -x
+  echo 'check lsst_build update works when a hash is specified'
+  current_hash=$(cd lsst_build; git log -n 1 --pretty=format:'%H')
+  LSST_BUILD_GITREV="$current_hash" ./bin/deploy
+
+  echo 'check lsst_build update works when a branch name is specified'
+  LSST_BUILD_GITREV='master' ./bin/deploy
+  set +x
+  ;;
+*)
+  echo "unknown MODE: $MODE"
+  exit 1
+  ;;
+esac
+
+# vim: tabstop=2 shiftwidth=2 expandtab

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -46,7 +46,7 @@ deploy*)
   esac
   echo -e "*** checking installed vs ${conda_packages} conda packages ***"
   conda list -e > "./etc/${conda_packages}"
-  git diff
+  git --no-pager diff
   rebuild pytest
   ;;
 versiondb*)

--- a/tests/docker-acceptance.sh
+++ b/tests/docker-acceptance.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eo pipefail
+
+( set -eo pipefail
+  cd tests
+  make
+)
+
+docker run -ti \
+  -v"$(pwd):$(pwd)" -w "$(pwd)" \
+  -e MODE="$MODE" \
+  lsstsw-testenv:latest bash -lc ./tests/acceptance.sh
+
+# vim: tabstop=2 shiftwidth=2 expandtab

--- a/tests/hadolint.sh
+++ b/tests/hadolint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+shopt -s globstar nullglob
+
+CHECK=( **/Dockerfile )
+IGNORE=()
+
+for c in "${!CHECK[@]}"; do
+  for i in "${IGNORE[@]}"; do
+    [[ ${CHECK[c]} == "$i" ]] && unset -v 'CHECK[c]'
+  done
+done
+[[ ${#CHECK[@]} -eq 0 ]] && { echo 'no files to check'; exit 0; }
+
+echo '---'
+echo 'check:'
+for c in "${CHECK[@]}"; do
+  echo "  - ${c}"
+done
+echo
+
+for f in "${CHECK[@]}"; do
+  docker run -ti -v "$(pwd):$(pwd)" -w "$(pwd)" \
+    hadolint/hadolint hadolint "$f"
+done
+
+# vim: tabstop=2 shiftwidth=2 expandtab

--- a/tests/make.sh
+++ b/tests/make.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+shopt -s globstar nullglob
+
+CHECK=( tests/**/Makefile )
+IGNORE=()
+
+for c in "${!CHECK[@]}"; do
+  for i in "${IGNORE[@]}"; do
+    [[ ${CHECK[c]} == "$i" ]] && unset -v 'CHECK[c]'
+  done
+done
+[[ ${#CHECK[@]} -eq 0 ]] && { echo 'no files to check'; exit 0; }
+
+echo '---'
+echo 'check:'
+for c in "${CHECK[@]}"; do
+  echo "  - ${c}"
+done
+echo
+
+for f in "${CHECK[@]}"; do
+  ( set -e
+    cd "$(dirname "$f")"
+    echo "checking $f"
+    make --dry-run --warn-undefined-variables
+  )
+done
+
+# vim: tabstop=2 shiftwidth=2 expandtab

--- a/tests/mdl.sh
+++ b/tests/mdl.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+shopt -s globstar nullglob
+
+CHECK=( **/*.md )
+IGNORE=()
+
+for c in "${!CHECK[@]}"; do
+  for i in "${IGNORE[@]}"; do
+    [[ ${CHECK[c]} == "$i" ]] && unset -v 'CHECK[c]'
+  done
+done
+[[ ${#CHECK[@]} -eq 0 ]] && { echo 'no files to check'; exit 0; }
+
+echo '---'
+echo 'check:'
+for c in "${CHECK[@]}"; do
+  echo "  - ${c}"
+done
+echo
+
+docker run -ti -v "$(pwd):$(pwd)" -w "$(pwd)" \
+  mivok/markdownlint:0.4.0 "${CHECK[@]}"
+
+# vim: tabstop=2 shiftwidth=2 expandtab

--- a/tests/shellcheck.sh
+++ b/tests/shellcheck.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+shopt -s globstar nullglob
+
+CHECK=( **/*.sh bin/* )
+IGNORE=( **/*.csh bin/flock-fd lsst_build/** )
+
+for c in "${!CHECK[@]}"; do
+  for i in "${IGNORE[@]}"; do
+    [[ ${CHECK[c]} == "$i" ]] && unset -v 'CHECK[c]'
+  done
+done
+[[ ${#CHECK[@]} -eq 0 ]] && { echo 'no files to check'; exit 0; }
+
+echo '---'
+echo 'check:'
+for c in "${CHECK[@]}"; do
+  echo "  - ${c}"
+done
+echo
+
+docker run -ti -v "$(pwd):$(pwd)" -w "$(pwd)" \
+  koalaman/shellcheck-alpine:v0.4.6 -x "${CHECK[@]}"
+
+# vim: tabstop=2 shiftwidth=2 expandtab

--- a/tests/yamllint.sh
+++ b/tests/yamllint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+shopt -s globstar nullglob
+
+CHECK=( **/*.yaml **/*.yml **/*.eyaml .travis.yml )
+EYAML=( **/*.eyaml )
+IGNORE=()
+
+# filter out plaintext versions of .eyaml files
+for e in "${!EYAML[@]}"; do
+  uneyaml=${EYAML[e]/eyaml/yaml}
+  for c in "${!CHECK[@]}"; do
+    [[ ${CHECK[c]} == "$uneyaml" ]] && unset -v 'CHECK[c]'
+  done
+done
+
+for c in "${!CHECK[@]}"; do
+  for i in "${IGNORE[@]}"; do
+    [[ ${CHECK[c]} == "$i" ]] && unset -v 'CHECK[c]'
+  done
+done
+[[ ${#CHECK[@]} -eq 0 ]] && { echo 'no files to check'; exit 0; }
+
+echo '---'
+echo 'check:'
+for c in "${CHECK[@]}"; do
+  echo "  - ${c}"
+done
+echo
+
+docker run -ti -v "$(pwd):/workdir" lsstsqre/yamllint:1.11.1 "${CHECK[@]}"
+
+# vim: tabstop=2 shiftwidth=2 expandtab


### PR DESCRIPTION
Additional tests, move large shell fragments out of `.travis.yaml`, and switch to running acceptance tests inside of a docker container.  There have been several unexplained failures in the default travis build env with truncated console output and switching over to our own docker image appears to resolve this.  However, it may add up to several minutes to each travis "job".