### PR TITLE
change default conda env name to lsst-scipipe

### DIFF
--- a/bin/setup.csh
+++ b/bin/setup.csh
@@ -43,7 +43,7 @@ rehash
 setenv MANPATH "$LSSTSW/lfs/share/man:"
 
 if ( ! $?LSST_CONDA_ENV_NAME ) then
-  set LSST_CONDA_ENV_NAME="lsst-dm-scipipe"
+  set LSST_CONDA_ENV_NAME="lsst-scipipe"
 endif
 # shellcheck disable=SC1091
 source activate "$LSST_CONDA_ENV_NAME"

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -25,7 +25,7 @@ export PATH="$LSSTSW/bin:$PATH"
 
 export MANPATH="$LSSTSW/lfs/share/man:"
 
-LSST_CONDA_ENV_NAME=${LSST_CONDA_ENV_NAME:-lsst-dm-scipipe}
+LSST_CONDA_ENV_NAME=${LSST_CONDA_ENV_NAME:-lsst-scipipe}
 # shellcheck disable=SC1091
 source activate "$LSST_CONDA_ENV_NAME"
 

--- a/etc/settings.cfg.sh
+++ b/etc/settings.cfg.sh
@@ -35,7 +35,7 @@ VERSIONDB=${LSSTSW}/versiondb
 EXCLUSIONS=${LSSTSW}/etc/exclusions.txt
 
 # name of conda env to create/update/use
-LSST_CONDA_ENV_NAME=${LSST_CONDA_ENV_NAME:-lsst-dm-scipipe}
+LSST_CONDA_ENV_NAME=${LSST_CONDA_ENV_NAME:-lsst-scipipe}
 
 #
 # exported variables


### PR DESCRIPTION
As this is slightly less long winded and still shouldn't conflict with
other env names.