### PR TITLE
Bump conda pytest versions to 3.6.2

### DIFF
--- a/etc/conda3_packages-linux-64.txt
+++ b/etc/conda3_packages-linux-64.txt
@@ -44,7 +44,7 @@ pycparser=2.17=py36_0
 pyopenssl=17.0.0=py36_0
 pyparsing=2.1.4=py36_0
 pyqt=5.6.0=py36_2
-pytest=3.2.1=py36_0
+pytest=3.6.2=py36_0
 python=3.6.2=0
 python-dateutil=2.6.1=py36_0
 pytz=2017.2=py36_0

--- a/etc/conda3_packages-osx-64.txt
+++ b/etc/conda3_packages-osx-64.txt
@@ -29,7 +29,7 @@ pycparser=2.17=py36_0
 pyopenssl=17.0.0=py36_0
 pyparsing=2.1.4=py36_0
 pyqt=5.6.0=py36_2
-pytest=3.2.1=py36_0
+pytest=3.6.2=py36_0
 python=3.6.2=0
 python-dateutil=2.6.1=py36_0
 pytz=2017.2=py36_0


### PR DESCRIPTION
This will make sure we are in line with the pytest version that we declare in eups