### PR TITLE
DM-15142: Create CI-sized DECam Dataset

### DIFF
--- a/etc/manifest.remap
+++ b/etc/manifest.remap
@@ -8,3 +8,6 @@
 [create]validation_data_cfht  None
 [create]validation_data_decam None
 [create]validation_data_hsc   None
+[create]ap_verify_testdata    None
+[create]ap_verify_hits2015    None
+[create]ap_verify_ci_hits2015 None


### PR DESCRIPTION
This PR registers all currently existing `ap_verify` datasets as undownloadable by `eups distrib`. All datasets are Git LFS repositories.