### PR TITLE
add cffi to the bleeding edge dependency lists

### DIFF
--- a/etc/conda3_bleed-linux-64.txt
+++ b/etc/conda3_bleed-linux-64.txt
@@ -4,6 +4,7 @@
 # future + pyyaml are lsst-build deps. See DM-15025
 astropy
 bottleneck
+cffi
 cython
 future
 h5py

--- a/etc/conda3_bleed-osx-64.txt
+++ b/etc/conda3_bleed-osx-64.txt
@@ -4,6 +4,7 @@
 # future + pyyaml are lsst-build deps. See DM-15025
 astropy
 bottleneck
+cffi
 cython
 future
 h5py


### PR DESCRIPTION
necessary for GalSim 2.0.6