### PR TITLE
add python to bleed conda env(s)

### DIFF
--- a/etc/conda3_bleed-linux-64.txt
+++ b/etc/conda3_bleed-linux-64.txt
@@ -14,6 +14,7 @@ numexpr
 numpy
 pandas
 pip
+python
 pyyaml
 requests
 scikit-learn

--- a/etc/conda3_bleed-osx-64.txt
+++ b/etc/conda3_bleed-osx-64.txt
@@ -13,6 +13,7 @@ numexpr
 numpy
 pandas
 pip
+python
 pyyaml
 requests
 scikit-learn


### PR DESCRIPTION
This is needed to fix conda downgrading python 3.6 -> 3.5 (even though
3.7 is available) when installing the "bleed" packages.