### PR TITLE
Add conda environment to published tag file.

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -81,6 +81,7 @@ PRODUCTS=("$@")
 . "${miniconda_path}/etc/profile.d/conda.sh"
 # shellcheck disable=SC1091
 conda activate "$LSST_CONDA_ENV_NAME"
+CONDA_ENV_REF="${LSST_SPLENV_REPO}@${LSST_CONDA_ENV_NAME#${SPLENV_BASE_NAME}-}"
 
 for prod in "${PRODUCTS[@]}"; do
   if [[ -z "$prod" ]]; then
@@ -130,7 +131,7 @@ if [[ ! -z $DISTRIBTAG && "$DISTRIBTAG" != "$BUILD" ]]; then
 
   match='EUPS distribution ([^ ]+) version list. Version 1.0'
   # shellcheck disable=SC1117
-  sub="EUPS distribution ${DISTRIBTAG} version list. Version 1.0\n#BUILD=\1"
+  sub="EUPS distribution ${DISTRIBTAG} version list. Version 1.0\n#BUILD=\1\n#CONDA_ENV=${CONDA_ENV_REF}"
   src_tag="${EUPS_PKGROOT}/tags/${BUILD}.list"
   dst_tag="${EUPS_PKGROOT}/tags/${DISTRIBTAG}.list"
 

--- a/etc/settings.cfg.sh
+++ b/etc/settings.cfg.sh
@@ -8,6 +8,7 @@
 # scipipe-conda-env reference
 LSST_SPLENV_REF=${LSST_SPLENV_REF:-984c9f7}
 SPLENV_BASE_NAME="lsst-scipipe"
+LSST_SPLENV_REPO=${LSST_SPLENV_REPO:-https://github.com/lsst/scipipe_conda_env.git}
 
 # top-level products
 PRODUCTS='lsst_distrib qserv_distrib dax_webserv'


### PR DESCRIPTION
This allows the environment used to build a tag to be discovered more easily.