### PR TITLE
Envconfig can't use the default ENV_REF

### DIFF
--- a/bin/envconfig
+++ b/bin/envconfig
@@ -166,7 +166,7 @@ export LSST_CONDA_ENV_NAME
 
 # definition EUPS_PATH depending on the environment:
 # including the last 7 characters of the environment name
-export EUPS_PATH="${LSSTSW}/stack/${LSST_SPLENV_REF}"
+export EUPS_PATH="${LSSTSW}/stack/${LSST_CONDA_ENV_NAME: -7}"
 echo "EUPS_PATH set to ${EUPS_PATH}"
 
 setup -r "$LSSTSW/lsst_build"


### PR DESCRIPTION
the environment reference to activated needs to be extracted from the environment name.