### PR TITLE
Avoid  environment consistency check when executing bin/deploy

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -45,7 +45,7 @@ usage() {
 
 		Specific options:
 	    -b          use bleeding edge conda packages
-	    -r REF      git ref in scipipe_conda_env (hash, branch, tag), create new end only if it does not exists
+	    -r REF      git ref in scipipe_conda_env (hash, branch, tag), create new env only if it does not exists
 	    -R REF      like -r, but always check if it is consistent with the pinned file
 	    -h          show this message
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -91,7 +91,7 @@ parse_args() {
 
   # We are intentionally not using gnu `getopt` due to portability concerns.
   # Sadly, this means no long options without a massive amount of boilerplate.
-  while getopts "23bhriR" opt; do
+  while getopts "23bhrR" opt; do
     case "$opt" in
     b)
       BLEED_DEPLOY=true
@@ -271,53 +271,53 @@ main() {
   if conda env list | grep "^$LSST_CONDA_ENV_NAME " > /dev/null && [[ $CHECKENV = false ]]; then
     echo "::: Environment $LSST_CONDA_ENV_NAME already deployed."
   else
-  (
-    echo "::: Deploy new environment $LSST_CONDA_ENV_NAME"
-    # Install packages on which the stack is known to depend
-    # conda may leave behind lock files from an uncompleted package
-    # installation attempt.  These need to be cleaned up before [re]attempting
-    # to install packages.
-    conda clean -y --all
-    if [[ $deploy_mode == "bleed" ]]; then
-      ARGS=()
-      ARGS+=('env' 'update')
-      ARGS+=('--name' "$LSST_CONDA_ENV_NAME")
-      ARGS+=("--file" "$env_file")
-      conda "${ARGS[@]}"
-    else
-      ARGS=()
-      ARGS+=('create')
-      ARGS+=('--name' "$LSST_CONDA_ENV_NAME")
-      ARGS+=('-y')
-      ARGS+=("--file" "$lock_file")
-      # check if env exists and is consistent with the lock file
-      tmp_lock="$(mktemp)"
-      if (conda run -n "${LSST_CONDA_ENV_NAME}" conda list --explicit > "${tmp_lock}"); then
-        # check if environment is unchanged
-        # -B ignores blank lines
-        if (diff -B "${tmp_lock}" "${lock_file}"); then
-          echo "Environment exists and is consistent with its definition"
+    (
+      echo "::: Deploy new environment $LSST_CONDA_ENV_NAME"
+      # Install packages on which the stack is known to depend
+      # conda may leave behind lock files from an uncompleted package
+      # installation attempt.  These need to be cleaned up before [re]attempting
+      # to install packages.
+      conda clean -y --all
+      if [[ $deploy_mode == "bleed" ]]; then
+        ARGS=()
+        ARGS+=('env' 'update')
+        ARGS+=('--name' "$LSST_CONDA_ENV_NAME")
+        ARGS+=("--file" "$env_file")
+        conda "${ARGS[@]}"
+      else
+        ARGS=()
+        ARGS+=('create')
+        ARGS+=('--name' "$LSST_CONDA_ENV_NAME")
+        ARGS+=('-y')
+        ARGS+=("--file" "$lock_file")
+        # check if env exists and is consistent with the lock file
+        tmp_lock="$(mktemp)"
+        if (conda run -n "${LSST_CONDA_ENV_NAME}" conda list --explicit > "${tmp_lock}"); then
+          # check if environment is unchanged
+          # -B ignores blank lines
+          if (diff -B "${tmp_lock}" "${lock_file}"); then
+            echo "Environment exists and is consistent with its definition"
+          else
+            # environment has changed, it will be recreated
+            conda "${ARGS[@]}"
+          fi
         else
-          # environment has changed, it will be recreated
+          # environment do not exist, it will be created
           conda "${ARGS[@]}"
         fi
-      else
-        # environment do not exist, it will be created
-        conda "${ARGS[@]}"
+        rm "${tmp_lock}"
       fi
-      rm "${tmp_lock}"
-    fi
 
-    # disable the conda install progress bar when not attached to a tty. Eg.,
-    # when running under CI
-    if [[ ! -t 1 ]]; then
-      ARGS+=("--quiet")
-    fi
+      # disable the conda install progress bar when not attached to a tty. Eg.,
+      # when running under CI
+      if [[ ! -t 1 ]]; then
+        ARGS+=("--quiet")
+      fi
 
-    echo "Cleaning conda environment..."
-    conda clean -y -a > /dev/null
-    echo "done"
-  )
+      echo "Cleaning conda environment..."
+      conda clean -y -a > /dev/null
+      echo "done"
+    )
   fi
 
   # intentionally outside of a lockfile subshell

--- a/bin/deploy
+++ b/bin/deploy
@@ -41,11 +41,12 @@ usage() {
   # note that heredocs are prefixed with tab chars
   fail "$(cat <<-EOF
 
-		Usage: $0 [-b] [-h] [-r]
+		Usage: $0 [-b] [-h] [-r] [-R]
 
 		Specific options:
 	    -b          use bleeding edge conda packages
-	    -r REF      git ref in scipipe_conda_env (hash, branch, tag)
+	    -r REF      git ref in scipipe_conda_env (hash, branch, tag), create new end only if it does not exists
+	    -R REF      like -r, but always check if it is consistent with the pinned file
 	    -h          show this message
 
 		EOF
@@ -90,7 +91,7 @@ parse_args() {
 
   # We are intentionally not using gnu `getopt` due to portability concerns.
   # Sadly, this means no long options without a massive amount of boilerplate.
-  while getopts "23bhr" opt; do
+  while getopts "23bhriR" opt; do
     case "$opt" in
     b)
       BLEED_DEPLOY=true
@@ -107,6 +108,11 @@ parse_args() {
     r)
       shift;
       ENVREF=$1
+      ;;
+    R)
+      shift;
+      ENVREF=$1
+      CHECKENV=true
       ;;
     *)
       usage "Unknown option: ${opt}"
@@ -137,6 +143,7 @@ main() {
   config_curl
 
   BLEED_DEPLOY=false
+  CHECKENV=false
 
   ENVREF=""
 
@@ -261,9 +268,12 @@ main() {
   local old_miniconda_pkgs_lock="${LSSTSW}/miniconda/.packages.deployed"
   [[ -e $old_miniconda_pkgs_lock ]] && rm "$old_miniconda_pkgs_lock"
 
+  if conda env list | grep "^$LSST_CONDA_ENV_NAME " > /dev/null && [[ $CHECKENV = false ]]; then
+    echo "::: Environment $LSST_CONDA_ENV_NAME already deployed."
+  else
   (
+    echo "::: Deploy new environment $LSST_CONDA_ENV_NAME"
     # Install packages on which the stack is known to depend
-
     # conda may leave behind lock files from an uncompleted package
     # installation attempt.  These need to be cleaned up before [re]attempting
     # to install packages.
@@ -308,6 +318,7 @@ main() {
     conda clean -y -a > /dev/null
     echo "done"
   )
+  fi
 
   # intentionally outside of a lockfile subshell
   # shellcheck disable=SC1091


### PR DESCRIPTION
I have added an extra option (-R) to check the consistency of the environment.