### PR TITLE
Improve help strings for -p/-t docs

### DIFF
--- a/bin/rebuild
+++ b/bin/rebuild
@@ -38,11 +38,11 @@ usage() {
 	It requires that the environment has previously been setup using envconfig.
 
 		 Specific options:
-	    -p            prepare only
+	    -p            prepare only (checkout and pull main for all packages and run "lsst-build prepare")
 	    -n            pass "--no-fetch" parameter to lsst_build
 	    -u            update repos.yaml
 	    -r <ref>      git reference (branch or tags) to be built
-	    -t <eupstag>  specify the eupstag to use
+	    -t <eupstag>  clone the finished build eups tag to the specified eupstag (e.g. "-t current")
 	    -h            show this message
 
 		EOF


### PR DESCRIPTION
Related to [DM-4131](https://jira.lsstcorp.org/browse/DM-4131): I just did a build and completely forgot about the `-t current` option that KT had pointed out on that ticket, because when I ran `-h` to get help, I didn't understand what the help message meant.

I also tweaked the help message for `-p`, as the meaning of "prepare" wasn't obvious.