### PR TITLE
DM-36477: Register ap_verify_ci_dc2 as an EUPS distrib exclusion.

### DIFF
--- a/etc/manifest.remap
+++ b/etc/manifest.remap
@@ -12,6 +12,7 @@
 [create]ap_verify_hits2015    None
 [create]ap_verify_ci_hits2015 None
 [create]ap_verify_ci_cosmos_pdr2 None
+[create]ap_verify_ci_dc2      None
 [create]ap_pipe_testdata      None
 [create]testdata_latiss_cpp   None
 [create]testdata_ci_hsc       None


### PR DESCRIPTION
This PR adds `ap_verify_ci_dc2` to `manifest.remap`, per SOP for LFS packages. This step should have been done when the repo was added to the build; we only avoided problems because it's not used as an explicit dependency anywhere. The problem was noticed on lsst/repos#145 but is otherwise unrelated to DM-36477.