### PR TITLE
DM-41137: Remove outdated build products

### DIFF
--- a/etc/settings.cfg.sh
+++ b/etc/settings.cfg.sh
@@ -11,7 +11,7 @@ SPLENV_BASE_NAME="lsst-scipipe"
 LSST_SPLENV_REPO=${LSST_SPLENV_REPO:-https://github.com/lsst/scipipe_conda_env.git}
 
 # top-level products
-PRODUCTS='lsst_distrib qserv_distrib dax_webserv'
+PRODUCTS='lsst_distrib'
 
 # change to ssh+git if push is needed
 VERSIONDB_REPO=${VERSIONDB_REPO:-https://github.com/lsst/versiondb.git}


### PR DESCRIPTION
The qserv_distrib and dax_webserv products are outdated and do not build any longer. I have removed them from the products list so that only lsst_distrib will be built by default now when calling rebuild with no arguments.