### PR TITLE
DM-41137: Remove quotes when appending products to args array

### DIFF
--- a/bin/rebuild
+++ b/bin/rebuild
@@ -178,8 +178,8 @@ fi
   ARGS+=("--version-git-repo=${VERSIONDB}")
   ARGS+=("$LSSTSW_BUILD_DIR")
   ARGS+=("${refs[@]}")
-  ARGS+=("${PRODUCTS[@]}")
-
+  ARGS+=(${PRODUCTS[@]})
+  
   lsst-build prepare "${ARGS[@]}"
 
   if [[ $VERSIONDB_PUSH == true ]]; then

--- a/bin/rebuild
+++ b/bin/rebuild
@@ -178,8 +178,10 @@ fi
   ARGS+=("--version-git-repo=${VERSIONDB}")
   ARGS+=("$LSSTSW_BUILD_DIR")
   ARGS+=("${refs[@]}")
-  ARGS+=(${PRODUCTS[@]})
-  
+  for products in "${PRODUCTS[@]}"; do
+    ARGS+=("${products}")
+  done
+
   lsst-build prepare "${ARGS[@]}"
 
   if [[ $VERSIONDB_PUSH == true ]]; then

--- a/bin/rebuild
+++ b/bin/rebuild
@@ -178,8 +178,8 @@ fi
   ARGS+=("--version-git-repo=${VERSIONDB}")
   ARGS+=("$LSSTSW_BUILD_DIR")
   ARGS+=("${refs[@]}")
-  for products in "${PRODUCTS[@]}"; do
-    ARGS+=("${products}")
+  for product in "${PRODUCTS[@]}"; do
+    ARGS+=("${product}")
   done
 
   lsst-build prepare "${ARGS[@]}"


### PR DESCRIPTION
This fixes a problem where products defined in the $PRODUCTS variable were incorrectly interpreted as a single string, causing the build to fail. The shellcheck tool complains about this syntax but it is the most straightforward way to perform this operation in bash.