### PR TITLE
DM-41151: Define products variable as array so that it is interpreted correctly

### DIFF
--- a/etc/settings.cfg.sh
+++ b/etc/settings.cfg.sh
@@ -11,7 +11,7 @@ SPLENV_BASE_NAME="lsst-scipipe"
 LSST_SPLENV_REPO=${LSST_SPLENV_REPO:-https://github.com/lsst/scipipe_conda_env.git}
 
 # top-level products
-PRODUCTS='lsst_distrib'
+PRODUCTS=("lsst_distrib")
 
 # change to ssh+git if push is needed
 VERSIONDB_REPO=${VERSIONDB_REPO:-https://github.com/lsst/versiondb.git}


### PR DESCRIPTION
The usage of quotes causes the products to be interpreted as a single string, which is incorrect. This breaks the rebuild command when multiple products are included in the `$PRODUCTS` variable.